### PR TITLE
Feat/debt

### DIFF
--- a/alembic/README
+++ b/alembic/README
@@ -1,0 +1,1 @@
+Generic single-database configuration.

--- a/alembic/env.py
+++ b/alembic/env.py
@@ -1,0 +1,86 @@
+from logging.config import fileConfig
+
+from sqlalchemy import engine_from_config
+from sqlalchemy import pool
+
+from alembic import context
+
+# Add our app imports
+import sys
+import os
+sys.path.append(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+from app.db.base import Base
+from app.db.models import *  # Import all models
+
+# this is the Alembic Config object, which provides
+# access to the values within the .ini file in use.
+config = context.config
+
+# Interpret the config file for Python logging.
+# This line sets up loggers basically.
+if config.config_file_name is not None:
+    fileConfig(config.config_file_name)
+
+# add your model's MetaData object here
+# for 'autogenerate' support
+# from myapp import mymodel
+# target_metadata = mymodel.Base.metadata
+target_metadata = Base.metadata
+
+# other values from the config, defined by the needs of env.py,
+# can be acquired:
+# my_important_option = config.get_main_option("my_important_option")
+# ... etc.
+
+
+def run_migrations_offline() -> None:
+    """Run migrations in 'offline' mode.
+
+    This configures the context with just a URL
+    and not an Engine, though an Engine is acceptable
+    here as well.  By skipping the Engine creation
+    we don't even need a DBAPI to be available.
+
+    Calls to context.execute() here emit the given string to the
+    script output.
+
+    """
+    url = config.get_main_option("sqlalchemy.url")
+    context.configure(
+        url=url,
+        target_metadata=target_metadata,
+        literal_binds=True,
+        dialect_opts={"paramstyle": "named"},
+    )
+
+    with context.begin_transaction():
+        context.run_migrations()
+
+
+def run_migrations_online() -> None:
+    """Run migrations in 'online' mode.
+
+    In this scenario we need to create an Engine
+    and associate a connection with the context.
+
+    """
+    connectable = engine_from_config(
+        config.get_section(config.config_ini_section, {}),
+        prefix="sqlalchemy.",
+        poolclass=pool.NullPool,
+    )
+
+    with connectable.connect() as connection:
+        context.configure(
+            connection=connection, target_metadata=target_metadata
+        )
+
+        with context.begin_transaction():
+            context.run_migrations()
+
+
+if context.is_offline_mode():
+    run_migrations_offline()
+else:
+    run_migrations_online()

--- a/alembic/script.py.mako
+++ b/alembic/script.py.mako
@@ -1,0 +1,28 @@
+"""${message}
+
+Revision ID: ${up_revision}
+Revises: ${down_revision | comma,n}
+Create Date: ${create_date}
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+${imports if imports else ""}
+
+# revision identifiers, used by Alembic.
+revision: str = ${repr(up_revision)}
+down_revision: Union[str, None] = ${repr(down_revision)}
+branch_labels: Union[str, Sequence[str], None] = ${repr(branch_labels)}
+depends_on: Union[str, Sequence[str], None] = ${repr(depends_on)}
+
+
+def upgrade() -> None:
+    """Upgrade schema."""
+    ${upgrades if upgrades else "pass"}
+
+
+def downgrade() -> None:
+    """Downgrade schema."""
+    ${downgrades if downgrades else "pass"}

--- a/app/api/routes/debt_routes.py
+++ b/app/api/routes/debt_routes.py
@@ -1,0 +1,297 @@
+from fastapi import APIRouter, Depends, HTTPException, status, Query
+from sqlalchemy.orm import Session
+from typing import Optional
+from app.schemas.debt_dto import (
+    DebtCreateDTO,
+    DebtUpdateDTO,
+    DebtResponse,
+    DebtListResponse,
+    DebtSummaryResponse,
+    DebtFilterDTO,
+    DebtMarkPaidDTO
+)
+from app.schemas.user_dto import UserResponse
+from app.services.debt_service import DebtService
+from app.core.security import get_current_user
+from app.db.base import get_db
+
+router = APIRouter(prefix="/debts", tags=["Debt Management"])
+
+# Constants
+DEBT_NOT_FOUND = "Debt not found"
+
+
+@router.post("/", response_model=DebtResponse, status_code=201)
+async def create_debt(
+    debt_data: DebtCreateDTO,
+    current_user: UserResponse = Depends(get_current_user),
+    db: Session = Depends(get_db)
+):
+    """
+    Create a new debt record.
+
+    Args:
+        debt_data (DebtCreateDTO): The debt data
+        current_user (UserResponse): The current user from token
+        db (Session): Database session
+
+    Returns:
+        DebtResponse: The created debt
+
+    Raises:
+        HTTPException: If wallet not found or invalid data
+    """
+    debt_service = DebtService(db)
+    try:
+        debt = debt_service.create_debt(debt_data, current_user.id)
+        return DebtResponse.model_validate(debt)
+    except ValueError as e:
+        if "not found" in str(e).lower():
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail=str(e)
+            )
+        else:
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail=str(e)
+            )
+
+
+@router.get("/", response_model=DebtListResponse)
+async def get_user_debts(
+    skip: int = Query(0, ge=0, description="Number of records to skip"),
+    limit: int = Query(100, ge=1, le=1000, description="Maximum number of records to return"),
+    debt_type: Optional[str] = Query(None, regex="^(owed|given)$", description="Filter by debt type"),
+    is_paid: Optional[bool] = Query(None, description="Filter by payment status"),
+    borrower: Optional[str] = Query(None, description="Filter by borrower name"),
+    overdue_only: Optional[bool] = Query(False, description="Show only overdue debts"),
+    wallet_id: Optional[int] = Query(None, description="Filter by wallet ID"),
+    current_user: UserResponse = Depends(get_current_user),
+    db: Session = Depends(get_db)
+):
+    """
+    Get all debts for the current user with optional filtering.
+
+    Args:
+        skip (int): Number of records to skip
+        limit (int): Maximum number of records to return
+        debt_type (str): Filter by debt type
+        is_paid (bool): Filter by payment status
+        borrower (str): Filter by borrower name
+        overdue_only (bool): Show only overdue debts
+        wallet_id (int): Filter by wallet ID
+        current_user (UserResponse): The current user from token
+        db (Session): Database session
+
+    Returns:
+        DebtListResponse: List of debts with total count
+    """
+    debt_service = DebtService(db)
+    
+    # Create filter object
+    filters = DebtFilterDTO(
+        debt_type=debt_type,
+        is_paid=is_paid,
+        borrower=borrower,
+        overdue_only=overdue_only,
+        wallet_id=wallet_id
+    )
+    
+    return debt_service.get_user_debts(current_user.id, filters, skip, limit)
+
+
+@router.get("/summary", response_model=DebtSummaryResponse)
+async def get_debt_summary(
+    current_user: UserResponse = Depends(get_current_user),
+    db: Session = Depends(get_db)
+):
+    """
+    Get debt summary for the current user.
+
+    Args:
+        current_user (UserResponse): The current user from token
+        db (Session): Database session
+
+    Returns:
+        DebtSummaryResponse: Summary of user's debts
+    """
+    debt_service = DebtService(db)
+    return debt_service.get_debt_summary(current_user.id)
+
+
+@router.get("/wallet/{wallet_id}")
+async def get_wallet_debts(
+    wallet_id: int,
+    current_user: UserResponse = Depends(get_current_user),
+    db: Session = Depends(get_db)
+):
+    """
+    Get all debts for a specific wallet.
+
+    Args:
+        wallet_id (int): The wallet ID
+        current_user (UserResponse): The current user from token
+        db (Session): Database session
+
+    Returns:
+        List[DebtResponse]: List of debts for the wallet
+
+    Raises:
+        HTTPException: If wallet not found or not owned by user
+    """
+    debt_service = DebtService(db)
+    try:
+        return debt_service.get_wallet_debts(wallet_id, current_user.id)
+    except ValueError as e:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail=str(e)
+        )
+
+
+@router.get("/{debt_id}", response_model=DebtResponse)
+async def get_debt(
+    debt_id: int,
+    current_user: UserResponse = Depends(get_current_user),
+    db: Session = Depends(get_db)
+):
+    """
+    Get a specific debt by ID.
+
+    Args:
+        debt_id (int): The debt ID
+        current_user (UserResponse): The current user from token
+        db (Session): Database session
+
+    Returns:
+        DebtResponse: The debt data
+
+    Raises:
+        HTTPException: If debt not found or not owned by user
+    """
+    debt_service = DebtService(db)
+    debt = debt_service.get_debt_by_id(debt_id, current_user.id)
+    
+    if not debt:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail=DEBT_NOT_FOUND
+        )
+    
+    return DebtResponse.model_validate(debt)
+
+
+@router.put("/{debt_id}", response_model=DebtResponse)
+async def update_debt(
+    debt_id: int,
+    debt_data: DebtUpdateDTO,
+    current_user: UserResponse = Depends(get_current_user),
+    db: Session = Depends(get_db)
+):
+    """
+    Update debt information.
+
+    Args:
+        debt_id (int): The debt ID
+        debt_data (DebtUpdateDTO): The update data
+        current_user (UserResponse): The current user from token
+        db (Session): Database session
+
+    Returns:
+        DebtResponse: The updated debt
+
+    Raises:
+        HTTPException: If debt not found or not owned by user
+    """
+    debt_service = DebtService(db)
+    try:
+        debt = debt_service.update_debt(debt_id, debt_data, current_user.id)
+        return DebtResponse.model_validate(debt)
+    except ValueError as e:
+        if "not found" in str(e).lower():
+            raise HTTPException(
+                status_code=status.HTTP_404_NOT_FOUND,
+                detail=str(e)
+            )
+        else:
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail=str(e)
+            )
+
+
+@router.patch("/{debt_id}/payment", response_model=DebtResponse)
+async def mark_debt_payment(
+    debt_id: int,
+    payment_data: DebtMarkPaidDTO,
+    current_user: UserResponse = Depends(get_current_user),
+    db: Session = Depends(get_db)
+):
+    """
+    Mark debt as paid or unpaid.
+
+    Args:
+        debt_id (int): The debt ID
+        payment_data (DebtMarkPaidDTO): Payment status data
+        current_user (UserResponse): The current user from token
+        db (Session): Database session
+
+    Returns:
+        DebtResponse: The updated debt
+
+    Raises:
+        HTTPException: If debt not found or not owned by user
+    """
+    debt_service = DebtService(db)
+    try:
+        debt = debt_service.mark_debt_as_paid(debt_id, payment_data, current_user.id)
+        return DebtResponse.model_validate(debt)
+    except ValueError as e:
+        if "not found" in str(e).lower():
+            raise HTTPException(
+                status_code=status.HTTP_404_NOT_FOUND,
+                detail=str(e)
+            )
+        else:
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail=str(e)
+            )
+
+
+@router.delete("/{debt_id}")
+async def delete_debt(
+    debt_id: int,
+    current_user: UserResponse = Depends(get_current_user),
+    db: Session = Depends(get_db)
+):
+    """
+    Delete a debt record.
+
+    Args:
+        debt_id (int): The debt ID
+        current_user (UserResponse): The current user from token
+        db (Session): Database session
+
+    Returns:
+        dict: Success message
+
+    Raises:
+        HTTPException: If debt not found or not owned by user
+    """
+    debt_service = DebtService(db)
+    try:
+        debt_service.delete_debt(debt_id, current_user.id)
+        return {"message": "Debt deleted successfully"}
+    except ValueError as e:
+        if "not found" in str(e).lower():
+            raise HTTPException(
+                status_code=status.HTTP_404_NOT_FOUND,
+                detail=str(e)
+            )
+        else:
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail=str(e)
+            )

--- a/app/db/models/__init__.py
+++ b/app/db/models/__init__.py
@@ -4,5 +4,6 @@ from app.db.models.refresh_token import RefreshToken
 from app.db.models.wallet import Wallet
 from app.db.models.transaction import Transaction, TransactionType, TransactionCategory
 from app.db.models.file import File, FileType
+from app.db.models.debt import Debt
 
-__all__ = ["User", "RefreshToken", "Wallet", "Transaction", "TransactionType", "TransactionCategory", "File", "FileType"]
+__all__ = ["User", "RefreshToken", "Wallet", "Transaction", "TransactionType", "TransactionCategory", "File", "FileType", "Debt"]

--- a/app/db/models/debt.py
+++ b/app/db/models/debt.py
@@ -1,0 +1,30 @@
+from sqlalchemy import Column, Integer, String, DateTime, Numeric, ForeignKey, Boolean, Text
+from sqlalchemy.orm import relationship
+from sqlalchemy.sql import func
+from app.db.base import Base
+
+
+class Debt(Base):
+    """Debt model for tracking money owed or lent"""
+    __tablename__ = "debts"
+
+    id = Column(Integer, primary_key=True, index=True)
+    amount = Column(Numeric(10, 2), nullable=False)
+    borrower = Column(String(100), nullable=False, index=True)  # Person who owes/is owed money
+    type = Column(String(20), nullable=False, index=True)  # 'owed' (money you're owed) or 'given' (money you owe)
+    is_paid = Column(Boolean, default=False, nullable=False, index=True)
+    due_date = Column(DateTime(timezone=True), nullable=True)
+    description = Column(Text, nullable=True)  # Additional details about the debt
+    
+    # Foreign keys
+    wallet_id = Column(Integer, ForeignKey("wallets.id", ondelete="CASCADE"), nullable=False)
+    
+    # Timestamps
+    created_at = Column(DateTime(timezone=True), server_default=func.now())
+    updated_at = Column(DateTime(timezone=True), onupdate=func.now())
+    
+    # Relationships
+    wallet = relationship("Wallet", back_populates="debts")
+
+    def __repr__(self):
+        return f"<Debt(id={self.id}, borrower='{self.borrower}', type='{self.type}', amount={self.amount}, is_paid={self.is_paid})>"

--- a/app/db/models/wallet.py
+++ b/app/db/models/wallet.py
@@ -18,8 +18,7 @@ class Wallet(Base):
     # Relationships
     user = relationship("User", back_populates="wallets")
     transactions = relationship("Transaction", back_populates="wallet", cascade="all, delete-orphan")
-    # TODO: Uncomment when Debt model is implemented  
-    # debts = relationship("Debt", back_populates="wallet", cascade="all, delete-orphan")
+    debts = relationship("Debt", back_populates="wallet", cascade="all, delete-orphan")
     # TODO: Uncomment when Transfer model is implemented
     # source_transfers = relationship("Transfer", foreign_keys="Transfer.source_wallet_id", back_populates="source_wallet")
     # target_transfers = relationship("Transfer", foreign_keys="Transfer.target_wallet_id", back_populates="target_wallet")

--- a/app/main.py
+++ b/app/main.py
@@ -1,7 +1,7 @@
 from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
 from app.core.config import settings
-from app.api.routes import auth_routes, wallet_routes, transaction_routes
+from app.api.routes import auth_routes, wallet_routes, transaction_routes, debt_routes
 
 app = FastAPI(
     title=settings.APP_NAME,
@@ -22,6 +22,7 @@ app.add_middleware(
 app.include_router(auth_routes.router)
 app.include_router(wallet_routes.router)
 app.include_router(transaction_routes.router)
+app.include_router(debt_routes.router)
 
 @app.get("/")
 async def root():

--- a/app/repositories/debt_repository.py
+++ b/app/repositories/debt_repository.py
@@ -218,7 +218,7 @@ class DebtRepository:
         unpaid_debts = total_debts - paid_debts
         
         # Count overdue debts
-        now = datetime.utcnow()
+        now = datetime.now(timezone.utc)
         overdue_debts = sum(
             1 for debt in debts 
             if debt.due_date and debt.due_date < now and not debt.is_paid

--- a/app/repositories/debt_repository.py
+++ b/app/repositories/debt_repository.py
@@ -1,0 +1,242 @@
+from typing import List, Optional
+from decimal import Decimal
+from datetime import datetime
+from sqlalchemy.orm import Session
+from sqlalchemy import and_, func, or_
+from app.db.models.debt import Debt
+from app.db.models.wallet import Wallet
+from app.schemas.debt_dto import DebtCreateDTO, DebtUpdateDTO, DebtFilterDTO
+
+
+class DebtRepository:
+    def __init__(self, db: Session):
+        self.db = db
+
+    def create(self, debt_data: DebtCreateDTO, user_id: int) -> Debt:
+        """
+        Create a new debt record
+
+        Args:
+            debt_data (DebtCreateDTO): The debt data
+            user_id (int): The user ID (for wallet ownership verification)
+
+        Returns:
+            Debt: The created debt
+
+        Raises:
+            ValueError: If wallet not found or not owned by user
+        """
+        # Verify wallet ownership
+        wallet = self.db.query(Wallet).filter(
+            and_(Wallet.id == debt_data.wallet_id, Wallet.user_id == user_id)
+        ).first()
+        
+        if not wallet:
+            raise ValueError("Wallet not found or not owned by user")
+
+        debt = Debt(
+            amount=debt_data.amount,
+            borrower=debt_data.borrower,
+            type=debt_data.type,
+            due_date=debt_data.due_date,
+            description=debt_data.description,
+            wallet_id=debt_data.wallet_id
+        )
+        
+        self.db.add(debt)
+        self.db.commit()
+        self.db.refresh(debt)
+        return debt
+
+    def get_by_id(self, debt_id: int) -> Optional[Debt]:
+        """Get debt by ID"""
+        return self.db.query(Debt).filter(Debt.id == debt_id).first()
+
+    def get_by_id_and_user(self, debt_id: int, user_id: int) -> Optional[Debt]:
+        """Get debt by ID and user (through wallet ownership)"""
+        return self.db.query(Debt).join(Wallet).filter(
+            and_(Debt.id == debt_id, Wallet.user_id == user_id)
+        ).first()
+
+    def get_user_debts(self, user_id: int, filters: Optional[DebtFilterDTO] = None, 
+                      skip: int = 0, limit: int = 100) -> List[Debt]:
+        """
+        Get all debts for a user with optional filtering
+
+        Args:
+            user_id (int): The user ID
+            filters (DebtFilterDTO): Optional filters
+            skip (int): Number of records to skip
+            limit (int): Maximum number of records to return
+
+        Returns:
+            List[Debt]: List of debts
+        """
+        query = self.db.query(Debt).join(Wallet).filter(Wallet.user_id == user_id)
+        
+        if filters:
+            if filters.debt_type:
+                query = query.filter(Debt.type == filters.debt_type)
+            
+            if filters.is_paid is not None:
+                query = query.filter(Debt.is_paid == filters.is_paid)
+            
+            if filters.borrower:
+                query = query.filter(Debt.borrower.ilike(f"%{filters.borrower}%"))
+            
+            if filters.overdue_only:
+                query = query.filter(
+                    and_(
+                        Debt.due_date < datetime.utcnow(),
+                        Debt.is_paid == False
+                    )
+                )
+            
+            if filters.wallet_id:
+                query = query.filter(Debt.wallet_id == filters.wallet_id)
+        
+        return query.order_by(Debt.created_at.desc()).offset(skip).limit(limit).all()
+
+    def count_user_debts(self, user_id: int, filters: Optional[DebtFilterDTO] = None) -> int:
+        """Count total debts for a user with optional filtering"""
+        query = self.db.query(Debt).join(Wallet).filter(Wallet.user_id == user_id)
+        
+        if filters:
+            if filters.debt_type:
+                query = query.filter(Debt.type == filters.debt_type)
+            
+            if filters.is_paid is not None:
+                query = query.filter(Debt.is_paid == filters.is_paid)
+            
+            if filters.borrower:
+                query = query.filter(Debt.borrower.ilike(f"%{filters.borrower}%"))
+            
+            if filters.overdue_only:
+                query = query.filter(
+                    and_(
+                        Debt.due_date < datetime.utcnow(),
+                        Debt.is_paid == False
+                    )
+                )
+            
+            if filters.wallet_id:
+                query = query.filter(Debt.wallet_id == filters.wallet_id)
+        
+        return query.count()
+
+    def get_wallet_debts(self, wallet_id: int, user_id: int) -> List[Debt]:
+        """Get all debts for a specific wallet"""
+        # Verify wallet ownership
+        wallet = self.db.query(Wallet).filter(
+            and_(Wallet.id == wallet_id, Wallet.user_id == user_id)
+        ).first()
+        
+        if not wallet:
+            raise ValueError("Wallet not found or not owned by user")
+
+        return self.db.query(Debt).filter(Debt.wallet_id == wallet_id).order_by(Debt.created_at.desc()).all()
+
+    def update(self, debt_id: int, debt_data: DebtUpdateDTO, user_id: int) -> Optional[Debt]:
+        """
+        Update debt information
+
+        Args:
+            debt_id (int): The debt ID
+            debt_data (DebtUpdateDTO): The update data
+            user_id (int): The user ID (for ownership verification)
+
+        Returns:
+            Optional[Debt]: The updated debt or None if not found
+
+        Raises:
+            ValueError: If debt not found or not owned by user
+        """
+        debt = self.get_by_id_and_user(debt_id, user_id)
+        if not debt:
+            raise ValueError("Debt not found or not owned by user")
+
+        # Update fields that are provided
+        update_data = debt_data.model_dump(exclude_unset=True)
+        for field, value in update_data.items():
+            setattr(debt, field, value)
+
+        self.db.commit()
+        self.db.refresh(debt)
+        return debt
+
+    def mark_as_paid(self, debt_id: int, is_paid: bool, user_id: int) -> Optional[Debt]:
+        """Mark debt as paid or unpaid"""
+        debt = self.get_by_id_and_user(debt_id, user_id)
+        if not debt:
+            raise ValueError("Debt not found or not owned by user")
+
+        debt.is_paid = is_paid
+        self.db.commit()
+        self.db.refresh(debt)
+        return debt
+
+    def delete(self, debt_id: int, user_id: int) -> bool:
+        """
+        Delete a debt
+
+        Args:
+            debt_id (int): The debt ID
+            user_id (int): The user ID (for ownership verification)
+
+        Returns:
+            bool: True if deleted, False if not found
+
+        Raises:
+            ValueError: If debt not found or not owned by user
+        """
+        debt = self.get_by_id_and_user(debt_id, user_id)
+        if not debt:
+            raise ValueError("Debt not found or not owned by user")
+
+        self.db.delete(debt)
+        self.db.commit()
+        return True
+
+    def get_user_debt_summary(self, user_id: int) -> dict:
+        """
+        Get debt summary for a user
+
+        Args:
+            user_id (int): The user ID
+
+        Returns:
+            dict: Summary statistics
+        """
+        debts = self.db.query(Debt).join(Wallet).filter(Wallet.user_id == user_id).all()
+        
+        total_debts = len(debts)
+        total_amount_owed = sum(debt.amount for debt in debts if debt.type == "owed")
+        total_amount_given = sum(debt.amount for debt in debts if debt.type == "given")
+        net_position = total_amount_owed - total_amount_given
+        
+        paid_debts = sum(1 for debt in debts if debt.is_paid)
+        unpaid_debts = total_debts - paid_debts
+        
+        # Count overdue debts
+        now = datetime.utcnow()
+        overdue_debts = sum(
+            1 for debt in debts 
+            if debt.due_date and debt.due_date < now and not debt.is_paid
+        )
+        
+        # Group by type
+        debts_by_type = {
+            "owed": sum(1 for debt in debts if debt.type == "owed"),
+            "given": sum(1 for debt in debts if debt.type == "given")
+        }
+        
+        return {
+            "total_debts": total_debts,
+            "total_amount_owed": total_amount_owed,
+            "total_amount_given": total_amount_given,
+            "net_position": net_position,
+            "paid_debts": paid_debts,
+            "unpaid_debts": unpaid_debts,
+            "overdue_debts": overdue_debts,
+            "debts_by_type": debts_by_type
+        }

--- a/app/repositories/debt_repository.py
+++ b/app/repositories/debt_repository.py
@@ -87,7 +87,7 @@ class DebtRepository:
             if filters.overdue_only:
                 query = query.filter(
                     and_(
-                        Debt.due_date < datetime.utcnow(),
+                        Debt.due_date < datetime.now(timezone.utc),
                         Debt.is_paid == False
                     )
                 )

--- a/app/repositories/debt_repository.py
+++ b/app/repositories/debt_repository.py
@@ -114,7 +114,7 @@ class DebtRepository:
             if filters.overdue_only:
                 query = query.filter(
                     and_(
-                        Debt.due_date < datetime.utcnow(),
+                        Debt.due_date < datetime.now(timezone.utc),
                         Debt.is_paid == False
                     )
                 )

--- a/app/schemas/debt_dto.py
+++ b/app/schemas/debt_dto.py
@@ -1,0 +1,73 @@
+from pydantic import BaseModel, Field, ConfigDict
+from decimal import Decimal
+from datetime import datetime
+from typing import Optional, List
+
+
+class DebtCreateDTO(BaseModel):
+    """Schema for creating a new debt"""
+    amount: Decimal = Field(..., gt=0, description="Debt amount (must be positive)")
+    borrower: str = Field(..., min_length=1, max_length=100, description="Person who owes/is owed money")
+    type: str = Field(..., pattern="^(owed|given)$", description="Debt type: 'owed' (money you're owed) or 'given' (money you owe)")
+    due_date: Optional[datetime] = Field(None, description="Due date for the debt (optional)")
+    description: Optional[str] = Field(None, max_length=500, description="Additional details about the debt")
+    wallet_id: int = Field(..., description="ID of the wallet this debt is associated with")
+
+
+class DebtUpdateDTO(BaseModel):
+    """Schema for updating debt information"""
+    amount: Optional[Decimal] = Field(None, gt=0, description="Debt amount (must be positive)")
+    borrower: Optional[str] = Field(None, min_length=1, max_length=100, description="Person who owes/is owed money")
+    type: Optional[str] = Field(None, pattern="^(owed|given)$", description="Debt type: 'owed' or 'given'")
+    due_date: Optional[datetime] = Field(None, description="Due date for the debt")
+    description: Optional[str] = Field(None, max_length=500, description="Additional details about the debt")
+    is_paid: Optional[bool] = Field(None, description="Whether the debt has been paid")
+
+
+class DebtResponse(BaseModel):
+    """Schema for debt response"""
+    model_config = ConfigDict(from_attributes=True)
+    
+    id: int
+    amount: Decimal
+    borrower: str
+    type: str
+    is_paid: bool
+    due_date: Optional[datetime] = None
+    description: Optional[str] = None
+    wallet_id: int
+    created_at: datetime
+    updated_at: Optional[datetime] = None
+
+
+class DebtListResponse(BaseModel):
+    """Schema for debt list response"""
+    debts: List[DebtResponse]
+    total: int
+
+
+class DebtSummaryResponse(BaseModel):
+    """Schema for debt summary response"""
+    total_debts: int
+    total_amount_owed: Decimal  # Money you're owed by others
+    total_amount_given: Decimal  # Money you owe to others
+    net_position: Decimal  # Positive if you're owed more, negative if you owe more
+    paid_debts: int
+    unpaid_debts: int
+    overdue_debts: int
+    debts_by_type: dict
+
+
+class DebtFilterDTO(BaseModel):
+    """Schema for filtering debts"""
+    debt_type: Optional[str] = Field(None, pattern="^(owed|given)$", description="Filter by debt type")
+    is_paid: Optional[bool] = Field(None, description="Filter by payment status")
+    borrower: Optional[str] = Field(None, description="Filter by borrower name")
+    overdue_only: Optional[bool] = Field(False, description="Show only overdue debts")
+    wallet_id: Optional[int] = Field(None, description="Filter by wallet ID")
+
+
+class DebtMarkPaidDTO(BaseModel):
+    """Schema for marking a debt as paid"""
+    is_paid: bool = Field(..., description="Payment status")
+    payment_note: Optional[str] = Field(None, max_length=255, description="Note about the payment")

--- a/app/services/debt_service.py
+++ b/app/services/debt_service.py
@@ -1,0 +1,179 @@
+from typing import List, Optional
+from sqlalchemy.orm import Session
+from app.db.models.debt import Debt
+from app.repositories.debt_repository import DebtRepository
+from app.schemas.debt_dto import (
+    DebtCreateDTO,
+    DebtUpdateDTO,
+    DebtResponse,
+    DebtListResponse,
+    DebtSummaryResponse,
+    DebtFilterDTO,
+    DebtMarkPaidDTO
+)
+
+DEBT_NOT_FOUND = "Debt not found"
+WALLET_NOT_FOUND = "Wallet not found or not owned by user"
+
+
+class DebtService:
+    def __init__(self, db: Session):
+        self.repository = DebtRepository(db)
+
+    def create_debt(self, debt_data: DebtCreateDTO, user_id: int) -> Debt:
+        """
+        Create a new debt
+
+        Args:
+            debt_data (DebtCreateDTO): The debt data
+            user_id (int): The user ID
+
+        Returns:
+            Debt: The created debt
+
+        Raises:
+            ValueError: If wallet not found or invalid data
+        """
+        try:
+            return self.repository.create(debt_data, user_id)
+        except ValueError as e:
+            raise ValueError(str(e))
+
+    def get_debt_by_id(self, debt_id: int, user_id: int) -> Optional[Debt]:
+        """
+        Get debt by ID
+
+        Args:
+            debt_id (int): The debt ID
+            user_id (int): The user ID
+
+        Returns:
+            Optional[Debt]: The debt or None if not found/not owned
+        """
+        return self.repository.get_by_id_and_user(debt_id, user_id)
+
+    def get_user_debts(self, user_id: int, filters: Optional[DebtFilterDTO] = None, 
+                      skip: int = 0, limit: int = 100) -> DebtListResponse:
+        """
+        Get user's debts with optional filtering
+
+        Args:
+            user_id (int): The user ID
+            filters (DebtFilterDTO): Optional filters
+            skip (int): Number of records to skip
+            limit (int): Maximum number of records to return
+
+        Returns:
+            DebtListResponse: List of debts with total count
+        """
+        debts = self.repository.get_user_debts(user_id, filters, skip, limit)
+        total = self.repository.count_user_debts(user_id, filters)
+        
+        debt_responses = [DebtResponse.model_validate(debt) for debt in debts]
+        
+        return DebtListResponse(
+            debts=debt_responses,
+            total=total
+        )
+
+    def get_wallet_debts(self, wallet_id: int, user_id: int) -> List[DebtResponse]:
+        """
+        Get all debts for a specific wallet
+
+        Args:
+            wallet_id (int): The wallet ID
+            user_id (int): The user ID
+
+        Returns:
+            List[DebtResponse]: List of debts for the wallet
+
+        Raises:
+            ValueError: If wallet not found or not owned by user
+        """
+        try:
+            debts = self.repository.get_wallet_debts(wallet_id, user_id)
+            return [DebtResponse.model_validate(debt) for debt in debts]
+        except ValueError as e:
+            raise ValueError(str(e))
+
+    def update_debt(self, debt_id: int, debt_data: DebtUpdateDTO, user_id: int) -> Optional[Debt]:
+        """
+        Update debt information
+
+        Args:
+            debt_id (int): The debt ID
+            debt_data (DebtUpdateDTO): The update data
+            user_id (int): The user ID
+
+        Returns:
+            Optional[Debt]: The updated debt
+
+        Raises:
+            ValueError: If debt not found or not owned by user
+        """
+        try:
+            return self.repository.update(debt_id, debt_data, user_id)
+        except ValueError as e:
+            raise ValueError(str(e))
+
+    def mark_debt_as_paid(self, debt_id: int, payment_data: DebtMarkPaidDTO, user_id: int) -> Optional[Debt]:
+        """
+        Mark debt as paid or unpaid
+
+        Args:
+            debt_id (int): The debt ID
+            payment_data (DebtMarkPaidDTO): Payment status data
+            user_id (int): The user ID
+
+        Returns:
+            Optional[Debt]: The updated debt
+
+        Raises:
+            ValueError: If debt not found or not owned by user
+        """
+        try:
+            return self.repository.mark_as_paid(debt_id, payment_data.is_paid, user_id)
+        except ValueError as e:
+            raise ValueError(str(e))
+
+    def delete_debt(self, debt_id: int, user_id: int) -> bool:
+        """
+        Delete a debt
+
+        Args:
+            debt_id (int): The debt ID
+            user_id (int): The user ID
+
+        Returns:
+            bool: True if deleted successfully
+
+        Raises:
+            ValueError: If debt not found or not owned by user
+        """
+        try:
+            return self.repository.delete(debt_id, user_id)
+        except ValueError as e:
+            raise ValueError(str(e))
+
+    def get_debt_summary(self, user_id: int) -> DebtSummaryResponse:
+        """
+        Get debt summary for a user
+
+        Args:
+            user_id (int): The user ID
+
+        Returns:
+            DebtSummaryResponse: Summary of user's debts
+        """
+        summary_data = self.repository.get_user_debt_summary(user_id)
+        
+        return DebtSummaryResponse(
+            total_debts=summary_data["total_debts"],
+            total_amount_owed=summary_data["total_amount_owed"],
+            total_amount_given=summary_data["total_amount_given"],
+            net_position=summary_data["net_position"],
+            paid_debts=summary_data["paid_debts"],
+            unpaid_debts=summary_data["unpaid_debts"],
+            overdue_debts=summary_data["overdue_debts"],
+            debts_by_type=summary_data["debts_by_type"]
+        )

--- a/tests/test_debt_management.py
+++ b/tests/test_debt_management.py
@@ -559,7 +559,7 @@ class TestDebtManagement:
             "amount": 300.00,
             "borrower": "Rachel",
             "type": "owed",
-            "due_date": (datetime.utcnow() + timedelta(days=10)).isoformat(),
+            "due_date": (datetime.now(timezone.utc) + timedelta(days=10)).isoformat(),
             "wallet_id": test_wallet["id"]
         }
         

--- a/tests/test_debt_management.py
+++ b/tests/test_debt_management.py
@@ -1,0 +1,607 @@
+import pytest
+from fastapi.testclient import TestClient
+from sqlalchemy.orm import Session
+from decimal import Decimal
+from datetime import datetime, timedelta
+from app.db.models.debt import Debt
+
+
+class TestDebtManagement:
+    """Test debt management endpoints"""
+
+    def test_create_debt_owed_success(self, client: TestClient, user_auth, test_wallet):
+        """Test successful creation of debt (money owed to user)"""
+        debt_data = {
+            "amount": 500.00,
+            "borrower": "John Doe",
+            "type": "owed",
+            "description": "Loan to John for car repair",
+            "due_date": (datetime.utcnow() + timedelta(days=30)).isoformat(),
+            "wallet_id": test_wallet["id"]
+        }
+        
+        response = client.post(
+            "/debts/",
+            json=debt_data,
+            headers=user_auth["headers"]
+        )
+        
+        assert response.status_code == 201
+        data = response.json()
+        assert float(data["amount"]) == 500.00
+        assert data["borrower"] == "John Doe"
+        assert data["type"] == "owed"
+        assert data["description"] == "Loan to John for car repair"
+        assert data["is_paid"] == False
+        assert data["wallet_id"] == test_wallet["id"]
+        assert "id" in data
+        assert "created_at" in data
+
+    def test_create_debt_given_success(self, client: TestClient, user_auth, test_wallet):
+        """Test successful creation of debt (money user owes)"""
+        debt_data = {
+            "amount": 300.00,
+            "borrower": "Jane Smith",
+            "type": "given",
+            "description": "Money borrowed from Jane",
+            "wallet_id": test_wallet["id"]
+        }
+        
+        response = client.post(
+            "/debts/",
+            json=debt_data,
+            headers=user_auth["headers"]
+        )
+        
+        assert response.status_code == 201
+        data = response.json()
+        assert float(data["amount"]) == 300.00
+        assert data["borrower"] == "Jane Smith"
+        assert data["type"] == "given"
+        assert data["description"] == "Money borrowed from Jane"
+        assert data["is_paid"] == False
+
+    def test_create_debt_unauthorized(self, client: TestClient, test_wallet):
+        """Test debt creation without authentication"""
+        debt_data = {
+            "amount": 100.00,
+            "borrower": "Someone",
+            "type": "owed",
+            "wallet_id": test_wallet["id"]
+        }
+        
+        response = client.post("/debts/", json=debt_data)
+        
+        assert response.status_code == 401
+
+    def test_create_debt_invalid_wallet(self, client: TestClient, user_auth):
+        """Test debt creation with non-existent wallet"""
+        debt_data = {
+            "amount": 100.00,
+            "borrower": "Someone",
+            "type": "owed",
+            "wallet_id": 99999
+        }
+        
+        response = client.post(
+            "/debts/",
+            json=debt_data,
+            headers=user_auth["headers"]
+        )
+        
+        assert response.status_code == 400
+        assert "not found" in response.json()["detail"].lower()
+
+    def test_create_debt_invalid_type(self, client: TestClient, user_auth, test_wallet):
+        """Test debt creation with invalid type"""
+        debt_data = {
+            "amount": 100.00,
+            "borrower": "Someone",
+            "type": "invalid_type",
+            "wallet_id": test_wallet["id"]
+        }
+        
+        response = client.post(
+            "/debts/",
+            json=debt_data,
+            headers=user_auth["headers"]
+        )
+        
+        assert response.status_code == 422  # Validation error
+
+    def test_create_debt_negative_amount(self, client: TestClient, user_auth, test_wallet):
+        """Test debt creation with negative amount"""
+        debt_data = {
+            "amount": -100.00,
+            "borrower": "Someone",
+            "type": "owed",
+            "wallet_id": test_wallet["id"]
+        }
+        
+        response = client.post(
+            "/debts/",
+            json=debt_data,
+            headers=user_auth["headers"]
+        )
+        
+        assert response.status_code == 422  # Validation error
+
+    def test_get_user_debts(self, client: TestClient, user_auth, test_wallet):
+        """Test getting user's debts"""
+        # Create a couple of debts first
+        debts = [
+            {
+                "amount": 400.00,
+                "borrower": "Alice",
+                "type": "owed",
+                "description": "Loan to Alice",
+                "wallet_id": test_wallet["id"]
+            },
+            {
+                "amount": 200.00,
+                "borrower": "Bob",
+                "type": "given",
+                "description": "Money borrowed from Bob",
+                "wallet_id": test_wallet["id"]
+            }
+        ]
+        
+        for debt_data in debts:
+            client.post(
+                "/debts/",
+                json=debt_data,
+                headers=user_auth["headers"]
+            )
+        
+        # Get debts
+        response = client.get("/debts/", headers=user_auth["headers"])
+        
+        assert response.status_code == 200
+        data = response.json()
+        assert "debts" in data
+        assert "total" in data
+        assert data["total"] >= 2  # At least the 2 we created
+        assert len(data["debts"]) >= 2
+
+    def test_get_debts_with_filters(self, client: TestClient, user_auth, test_wallet):
+        """Test getting debts with filters"""
+        # Create debts with different types
+        debts = [
+            {
+                "amount": 500.00,
+                "borrower": "Charlie",
+                "type": "owed",
+                "description": "Money owed by Charlie",
+                "wallet_id": test_wallet["id"]
+            },
+            {
+                "amount": 300.00,
+                "borrower": "Diana",
+                "type": "given",
+                "description": "Money owed to Diana",
+                "wallet_id": test_wallet["id"]
+            },
+            {
+                "amount": 150.00,
+                "borrower": "Eve",
+                "type": "owed",
+                "description": "Small loan to Eve",
+                "wallet_id": test_wallet["id"]
+            }
+        ]
+        
+        for debt_data in debts:
+            client.post(
+                "/debts/",
+                json=debt_data,
+                headers=user_auth["headers"]
+            )
+        
+        # Filter by type (owed)
+        response = client.get(
+            "/debts/",
+            params={"debt_type": "owed"},
+            headers=user_auth["headers"]
+        )
+        
+        assert response.status_code == 200
+        data = response.json()
+        owed_debts = [d for d in data["debts"] if d["type"] == "owed"]
+        assert len(owed_debts) >= 2
+        
+        # Filter by type (given)
+        response = client.get(
+            "/debts/",
+            params={"debt_type": "given"},
+            headers=user_auth["headers"]
+        )
+        
+        assert response.status_code == 200
+        data = response.json()
+        given_debts = [d for d in data["debts"] if d["type"] == "given"]
+        assert len(given_debts) >= 1
+
+        # Filter by borrower
+        response = client.get(
+            "/debts/",
+            params={"borrower": "Charlie"},
+            headers=user_auth["headers"]
+        )
+        
+        assert response.status_code == 200
+        data = response.json()
+        charlie_debts = [d for d in data["debts"] if "Charlie" in d["borrower"]]
+        assert len(charlie_debts) >= 1
+
+    def test_get_debt_by_id(self, client: TestClient, user_auth, test_wallet):
+        """Test getting specific debt by ID"""
+        # Create a debt
+        debt_data = {
+            "amount": 750.00,
+            "borrower": "Frank",
+            "type": "owed",
+            "description": "Big loan to Frank",
+            "wallet_id": test_wallet["id"]
+        }
+        
+        create_response = client.post(
+            "/debts/",
+            json=debt_data,
+            headers=user_auth["headers"]
+        )
+        debt_id = create_response.json()["id"]
+        
+        # Get the debt
+        response = client.get(
+            f"/debts/{debt_id}",
+            headers=user_auth["headers"]
+        )
+        
+        assert response.status_code == 200
+        data = response.json()
+        assert data["id"] == debt_id
+        assert float(data["amount"]) == 750.00
+        assert data["borrower"] == "Frank"
+
+    def test_get_debt_not_found(self, client: TestClient, user_auth):
+        """Test getting non-existent debt"""
+        response = client.get("/debts/99999", headers=user_auth["headers"])
+        
+        assert response.status_code == 404
+        assert "not found" in response.json()["detail"].lower()
+
+    def test_update_debt_success(self, client: TestClient, user_auth, test_wallet):
+        """Test successful debt update"""
+        # Create debt
+        debt_data = {
+            "amount": 400.00,
+            "borrower": "Grace",
+            "type": "owed",
+            "description": "Original description",
+            "wallet_id": test_wallet["id"]
+        }
+        
+        create_response = client.post(
+            "/debts/",
+            json=debt_data,
+            headers=user_auth["headers"]
+        )
+        debt_id = create_response.json()["id"]
+        
+        # Update debt
+        update_data = {
+            "amount": 600.00,
+            "description": "Updated description",
+            "due_date": (datetime.utcnow() + timedelta(days=15)).isoformat()
+        }
+        
+        response = client.put(
+            f"/debts/{debt_id}",
+            json=update_data,
+            headers=user_auth["headers"]
+        )
+        
+        assert response.status_code == 200
+        data = response.json()
+        assert float(data["amount"]) == 600.00
+        assert data["description"] == "Updated description"
+        assert data["due_date"] is not None
+
+    def test_update_debt_not_found(self, client: TestClient, user_auth):
+        """Test updating non-existent debt"""
+        update_data = {"amount": 100.00}
+        
+        response = client.put(
+            "/debts/99999",
+            json=update_data,
+            headers=user_auth["headers"]
+        )
+        
+        assert response.status_code == 404
+
+    def test_mark_debt_as_paid(self, client: TestClient, user_auth, test_wallet):
+        """Test marking debt as paid"""
+        # Create debt
+        debt_data = {
+            "amount": 250.00,
+            "borrower": "Henry",
+            "type": "owed",
+            "wallet_id": test_wallet["id"]
+        }
+        
+        create_response = client.post(
+            "/debts/",
+            json=debt_data,
+            headers=user_auth["headers"]
+        )
+        debt_id = create_response.json()["id"]
+        
+        # Mark as paid
+        payment_data = {
+            "is_paid": True,
+            "payment_note": "Paid in full on time"
+        }
+        
+        response = client.patch(
+            f"/debts/{debt_id}/payment",
+            json=payment_data,
+            headers=user_auth["headers"]
+        )
+        
+        assert response.status_code == 200
+        data = response.json()
+        assert data["is_paid"] == True
+
+    def test_mark_debt_as_unpaid(self, client: TestClient, user_auth, test_wallet):
+        """Test marking debt as unpaid (reversing payment)"""
+        # Create and mark debt as paid first
+        debt_data = {
+            "amount": 350.00,
+            "borrower": "Ivy",
+            "type": "given",
+            "wallet_id": test_wallet["id"]
+        }
+        
+        create_response = client.post(
+            "/debts/",
+            json=debt_data,
+            headers=user_auth["headers"]
+        )
+        debt_id = create_response.json()["id"]
+        
+        # Mark as paid first
+        client.patch(
+            f"/debts/{debt_id}/payment",
+            json={"is_paid": True},
+            headers=user_auth["headers"]
+        )
+        
+        # Mark as unpaid
+        payment_data = {
+            "is_paid": False
+        }
+        
+        response = client.patch(
+            f"/debts/{debt_id}/payment",
+            json=payment_data,
+            headers=user_auth["headers"]
+        )
+        
+        assert response.status_code == 200
+        data = response.json()
+        assert data["is_paid"] == False
+
+    def test_delete_debt_success(self, client: TestClient, user_auth, test_wallet):
+        """Test successful debt deletion"""
+        # Create debt
+        debt_data = {
+            "amount": 150.00,
+            "borrower": "Jack",
+            "type": "owed",
+            "wallet_id": test_wallet["id"]
+        }
+        
+        create_response = client.post(
+            "/debts/",
+            json=debt_data,
+            headers=user_auth["headers"]
+        )
+        debt_id = create_response.json()["id"]
+        
+        # Delete debt
+        response = client.delete(
+            f"/debts/{debt_id}",
+            headers=user_auth["headers"]
+        )
+        
+        assert response.status_code == 200
+        assert "deleted successfully" in response.json()["message"].lower()
+
+    def test_delete_debt_not_found(self, client: TestClient, user_auth):
+        """Test deleting non-existent debt"""
+        response = client.delete("/debts/99999", headers=user_auth["headers"])
+        
+        assert response.status_code == 404
+
+    def test_get_debt_summary(self, client: TestClient, user_auth, test_wallet):
+        """Test getting debt summary"""
+        # Create various debts
+        debts = [
+            {
+                "amount": 1000.00,
+                "borrower": "Kelly",
+                "type": "owed",
+                "wallet_id": test_wallet["id"]
+            },
+            {
+                "amount": 500.00,
+                "borrower": "Liam",
+                "type": "owed",
+                "wallet_id": test_wallet["id"]
+            },
+            {
+                "amount": 300.00,
+                "borrower": "Mia",
+                "type": "given",
+                "wallet_id": test_wallet["id"]
+            },
+            {
+                "amount": 200.00,
+                "borrower": "Noah",
+                "type": "given",
+                "wallet_id": test_wallet["id"]
+            }
+        ]
+        
+        debt_ids = []
+        for debt_data in debts:
+            response = client.post(
+                "/debts/",
+                json=debt_data,
+                headers=user_auth["headers"]
+            )
+            debt_ids.append(response.json()["id"])
+        
+        # Mark one debt as paid
+        client.patch(
+            f"/debts/{debt_ids[0]}/payment",
+            json={"is_paid": True},
+            headers=user_auth["headers"]
+        )
+        
+        # Get summary
+        response = client.get("/debts/summary", headers=user_auth["headers"])
+        
+        assert response.status_code == 200
+        data = response.json()
+        assert "total_debts" in data
+        assert "total_amount_owed" in data
+        assert "total_amount_given" in data
+        assert "net_position" in data
+        assert "paid_debts" in data
+        assert "unpaid_debts" in data
+        assert "overdue_debts" in data
+        assert "debts_by_type" in data
+        
+        # Verify calculations
+        assert data["total_debts"] >= 4
+        assert float(data["total_amount_owed"]) >= 1500.00  # 1000 + 500
+        assert float(data["total_amount_given"]) >= 500.00   # 300 + 200
+        assert float(data["net_position"]) >= 1000.00       # 1500 - 500
+        assert data["paid_debts"] >= 1
+        assert data["unpaid_debts"] >= 3
+
+    def test_get_wallet_debts(self, client: TestClient, user_auth):
+        """Test getting debts for a specific wallet"""
+        # Create two wallets
+        wallet1_data = {
+            "name": "Wallet 1",
+            "type": "checking",
+            "balance": 1000.00
+        }
+        
+        wallet2_data = {
+            "name": "Wallet 2", 
+            "type": "savings",
+            "balance": 2000.00
+        }
+        
+        wallet1_response = client.post("/wallets/", json=wallet1_data, headers=user_auth["headers"])
+        wallet2_response = client.post("/wallets/", json=wallet2_data, headers=user_auth["headers"])
+        
+        wallet1_id = wallet1_response.json()["id"]
+        wallet2_id = wallet2_response.json()["id"]
+        
+        # Create debts for each wallet
+        debt1 = {
+            "amount": 500.00,
+            "borrower": "Olivia",
+            "type": "owed",
+            "wallet_id": wallet1_id
+        }
+        
+        debt2 = {
+            "amount": 300.00,
+            "borrower": "Paul",
+            "type": "given",
+            "wallet_id": wallet2_id
+        }
+        
+        client.post("/debts/", json=debt1, headers=user_auth["headers"])
+        client.post("/debts/", json=debt2, headers=user_auth["headers"])
+        
+        # Get debts for wallet 1
+        response = client.get(
+            f"/debts/wallet/{wallet1_id}",
+            headers=user_auth["headers"]
+        )
+        
+        assert response.status_code == 200
+        data = response.json()
+        assert isinstance(data, list)
+        # Should only contain debts for wallet 1
+        for debt in data:
+            assert debt["wallet_id"] == wallet1_id
+
+    def test_overdue_debts_filter(self, client: TestClient, user_auth, test_wallet):
+        """Test filtering for overdue debts"""
+        # Create an overdue debt (due date in the past)
+        overdue_debt = {
+            "amount": 400.00,
+            "borrower": "Quinn",
+            "type": "owed",
+            "due_date": (datetime.utcnow() - timedelta(days=5)).isoformat(),
+            "wallet_id": test_wallet["id"]
+        }
+        
+        # Create a future debt
+        future_debt = {
+            "amount": 300.00,
+            "borrower": "Rachel",
+            "type": "owed",
+            "due_date": (datetime.utcnow() + timedelta(days=10)).isoformat(),
+            "wallet_id": test_wallet["id"]
+        }
+        
+        client.post("/debts/", json=overdue_debt, headers=user_auth["headers"])
+        client.post("/debts/", json=future_debt, headers=user_auth["headers"])
+        
+        # Filter for overdue debts only
+        response = client.get(
+            "/debts/",
+            params={"overdue_only": True},
+            headers=user_auth["headers"]
+        )
+        
+        assert response.status_code == 200
+        data = response.json()
+        # Should contain at least the overdue debt we created
+        overdue_debts = [d for d in data["debts"] if not d["is_paid"]]
+        assert len(overdue_debts) >= 1
+
+    def test_debt_operations_unauthorized(self, client: TestClient):
+        """Test debt operations without authentication"""
+        operations = [
+            ("GET", "/debts/", None),
+            ("POST", "/debts/", {"amount": 100, "borrower": "Someone", "type": "owed", "wallet_id": 1}),
+            ("GET", "/debts/1", None),
+            ("PUT", "/debts/1", {"amount": 150}),
+            ("PATCH", "/debts/1/payment", {"is_paid": True}),
+            ("DELETE", "/debts/1", None),
+            ("GET", "/debts/summary", None),
+            ("GET", "/debts/wallet/1", None),
+        ]
+        
+        for method, url, data in operations:
+            if method == "GET":
+                response = client.get(url)
+            elif method == "POST":
+                response = client.post(url, json=data)
+            elif method == "PUT":
+                response = client.put(url, json=data)
+            elif method == "PATCH":
+                response = client.patch(url, json=data)
+            elif method == "DELETE":
+                response = client.delete(url)
+            
+            assert response.status_code == 401

--- a/tests/test_debt_management.py
+++ b/tests/test_debt_management.py
@@ -292,7 +292,7 @@ class TestDebtManagement:
         update_data = {
             "amount": 600.00,
             "description": "Updated description",
-            "due_date": (datetime.utcnow() + timedelta(days=15)).isoformat()
+            "due_date": (datetime.now(timezone.utc) + timedelta(days=15)).isoformat()
         }
         
         response = client.put(

--- a/tests/test_debt_management.py
+++ b/tests/test_debt_management.py
@@ -550,7 +550,7 @@ class TestDebtManagement:
             "amount": 400.00,
             "borrower": "Quinn",
             "type": "owed",
-            "due_date": (datetime.utcnow() - timedelta(days=5)).isoformat(),
+            "due_date": (datetime.now(timezone.utc) - timedelta(days=5)).isoformat(),
             "wallet_id": test_wallet["id"]
         }
         

--- a/tests/test_debt_management.py
+++ b/tests/test_debt_management.py
@@ -16,7 +16,7 @@ class TestDebtManagement:
             "borrower": "John Doe",
             "type": "owed",
             "description": "Loan to John for car repair",
-            "due_date": (datetime.utcnow() + timedelta(days=30)).isoformat(),
+            "due_date": (datetime.now(timezone.utc) + timedelta(days=30)).isoformat(),
             "wallet_id": test_wallet["id"]
         }
         


### PR DESCRIPTION
This pull request introduces a comprehensive "Debt" feature to the application, enabling users to track, manage, and summarize debts (both owed and given) associated with their wallets. The implementation includes database model additions, repository and service layers, API endpoints, and integration with the existing application structure.

The most important changes are:

**Debt Model and Database Integration**
- Added a new `Debt` model (`app/db/models/debt.py`) with fields for amount, borrower, type (owed/given), payment status, due date, and wallet association. Also updated the `Wallet` model to include a relationship to debts. [[1]](diffhunk://#diff-96ea2a87e167c47d1511d7caa1bd86a0eac45eceb8ecf6d001ef5ae3ab51368dR1-R30) [[2]](diffhunk://#diff-fbc4d0155b0ed472532f8d7b7bd4846674dd140e739c7cba8f61389fc9014787L21-R21)
- Registered the `Debt` model in the models `__init__.py` for proper import and Alembic autogeneration.

**Repository and Service Layer**
- Implemented `DebtRepository` (`app/repositories/debt_repository.py`) to handle CRUD operations, filtering, summary statistics, and ownership validation for debts.

**API Endpoints**
- Added a new router `debt_routes.py` with endpoints to create, retrieve (with filters and summary), update, mark as paid/unpaid, and delete debts. Endpoints enforce user authentication and wallet ownership.
- Integrated the new debt routes into the FastAPI app (`app/main.py`). [[1]](diffhunk://#diff-990f7e4140fab1ad82afc787505090b64d4024e63a891405cd9085e7e6b249ddL4-R4) [[2]](diffhunk://#diff-990f7e4140fab1ad82afc787505090b64d4024e63a891405cd9085e7e6b249ddR25)

**Alembic Migration Support**
- Updated Alembic configuration (`alembic/env.py`, `alembic/README`, `alembic/script.py.mako`) to support migrations for the new debt model and ensure database schema consistency. [[1]](diffhunk://#diff-cd4d26a53ff97e019b612811dfa604ba24d5dfd2f4dc1b195f3e74d85c38e630R1-R86) [[2]](diffhunk://#diff-8ed52cd48b623cb510db84f21ba82f6e78a573e439490d6f9afa02d0981f61a0R1) [[3]](diffhunk://#diff-f205a44c5aa9f79c6aa297e02809df6db77befcf48c6c9661d5daa2854e79f2cR1-R28)